### PR TITLE
Fix frontend build error

### DIFF
--- a/client/src/pages/TrackOrder.jsx
+++ b/client/src/pages/TrackOrder.jsx
@@ -2,7 +2,7 @@ import React, { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { useSocket } from '../context/SocketContext';
 import SummaryApi from '../common/SummaryApi';
-import { toast } from 'react-toastify';
+import toast from 'react-hot-toast';
 
 const TrackOrder = () => {
   const { orderId } = useParams();


### PR DESCRIPTION
Replace `react-toastify` import with `react-hot-toast` to resolve build error and avoid new dependency.

The build was failing because `react-toastify` was imported in `TrackOrder.jsx` but was not installed. The project already uses `react-hot-toast` for notifications, so this change aligns the dependency and fixes the build issue without introducing a new library.